### PR TITLE
feat(home-news): 관리자 홈 뉴스 CRUD 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,8 @@ out/
 .vscode/
 
 application.properties
+application-local.properties
+application-dev.properties
 
 # Environment variables
 .env

--- a/src/main/java/wisoft/labservice/domain/home/controller/AdminNewsController.java
+++ b/src/main/java/wisoft/labservice/domain/home/controller/AdminNewsController.java
@@ -1,0 +1,51 @@
+package wisoft.labservice.domain.home.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import wisoft.labservice.domain.home.dto.NewsCreateRequest;
+import wisoft.labservice.domain.home.dto.NewsResponse;
+import wisoft.labservice.domain.home.dto.NewsUpdateRequest;
+import wisoft.labservice.domain.home.service.NewsService;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.Operation;
+
+
+@Tag(name = "Admin Home - News", description = "관리자 홈 뉴스 관리 API")
+@RestController
+@RequestMapping("/admin/home/news")
+@RequiredArgsConstructor
+public class AdminNewsController {
+
+    private final NewsService newsService;
+
+    @Operation(summary = "뉴스 목록 조회", description = "관리자용 뉴스 목록을 조회합니다.")
+    @GetMapping
+    public List<NewsResponse> getNewsList() {
+        return newsService.findAll()
+                .stream()
+                .map(NewsResponse::from)
+                .toList();
+    }
+
+    @Operation(summary = "뉴스 등록")
+    @PostMapping
+    public NewsResponse create(@RequestBody NewsCreateRequest req) {
+        return NewsResponse.from(newsService.create(req));
+    }
+
+    @Operation(summary = "뉴스 수정")
+    @PatchMapping("/{id}")
+    public void update(@PathVariable String id,
+                       @RequestBody NewsUpdateRequest req) {
+        newsService.update(id, req);
+    }
+
+    @Operation(summary = "뉴스 삭제")
+    @DeleteMapping("/{id}")
+    public void delete(@PathVariable String id) {
+        newsService.delete(id);
+    }
+}

--- a/src/main/java/wisoft/labservice/domain/home/dto/NewsCreateRequest.java
+++ b/src/main/java/wisoft/labservice/domain/home/dto/NewsCreateRequest.java
@@ -1,0 +1,12 @@
+package wisoft.labservice.domain.home.dto;
+
+import lombok.Getter;
+
+@Getter
+public class NewsCreateRequest {
+
+    private String title;      // 필수
+    private String detail;     // optional
+    private Boolean isActive;  // optional (default = true)
+    private Boolean isPinned;  // optional (default = false)
+}

--- a/src/main/java/wisoft/labservice/domain/home/dto/NewsResponse.java
+++ b/src/main/java/wisoft/labservice/domain/home/dto/NewsResponse.java
@@ -1,0 +1,30 @@
+package wisoft.labservice.domain.home.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import wisoft.labservice.domain.home.entity.News;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class NewsResponse {
+
+    private String id;
+    private String title;
+    private String detail;
+    private Boolean isActive;
+    private Boolean isPinned;
+    private LocalDateTime createdAt;
+
+    public static NewsResponse from(News news) {
+        return new NewsResponse(
+                news.getId(),
+                news.getTitle(),
+                news.getDetail(),
+                news.getIsActive(),
+                news.getIsPinned(),
+                news.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/wisoft/labservice/domain/home/dto/NewsUpdateRequest.java
+++ b/src/main/java/wisoft/labservice/domain/home/dto/NewsUpdateRequest.java
@@ -1,0 +1,12 @@
+package wisoft.labservice.domain.home.dto;
+
+import lombok.Getter;
+
+@Getter
+public class NewsUpdateRequest {
+
+    private String title;
+    private String detail;
+    private Boolean isActive;
+    private Boolean isPinned;
+}

--- a/src/main/java/wisoft/labservice/domain/home/entity/News.java
+++ b/src/main/java/wisoft/labservice/domain/home/entity/News.java
@@ -8,47 +8,62 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "news")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class News {
-    
+
     @Id
     @Column(length = 200)
     private String id;
-    
+
     @Column(nullable = false, length = 200)
     private String title;
-    
+
     @Column(columnDefinition = "TEXT")
     private String detail;
-    
-    @Column(name = "is_pinned")
+
+    @Column(name = "is_active", nullable = false)
+    private Boolean isActive = true;
+
+    @Column(name = "is_pinned", nullable = false)
     private Boolean isPinned = false;
-    
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
     @Builder
-    public News(String id, String title, String detail, Boolean isPinned) {
+    public News(String id,
+                String title,
+                String detail,
+                Boolean isActive,
+                Boolean isPinned) {
         this.id = id;
         this.title = title;
         this.detail = detail;
+        this.isActive = isActive != null ? isActive : true;
         this.isPinned = isPinned != null ? isPinned : false;
     }
-    
+
     public void updateTitle(String title) {
         this.title = title;
     }
-    
+
     public void updateDetail(String detail) {
         this.detail = detail;
     }
-    
-    public void togglePin() {
-        this.isPinned = !this.isPinned;
+
+    public void updateActive(Boolean isActive) {
+        this.isActive = isActive;
     }
-    
-    public void setPinned(Boolean isPinned) {
+
+    public void updatePinned(Boolean isPinned) {
         this.isPinned = isPinned;
     }
 }

--- a/src/main/java/wisoft/labservice/domain/home/repository/NewsRepository.java
+++ b/src/main/java/wisoft/labservice/domain/home/repository/NewsRepository.java
@@ -1,0 +1,12 @@
+package wisoft.labservice.domain.home.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import wisoft.labservice.domain.home.entity.News;
+
+import java.util.List;
+
+public interface NewsRepository extends JpaRepository<News, String> {
+
+    // 관리자 뉴스 목록 (최신순)
+    List<News> findAllByOrderByCreatedAtDesc();
+}

--- a/src/main/java/wisoft/labservice/domain/home/service/NewsService.java
+++ b/src/main/java/wisoft/labservice/domain/home/service/NewsService.java
@@ -1,0 +1,70 @@
+package wisoft.labservice.domain.home.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import wisoft.labservice.domain.home.dto.NewsCreateRequest;
+import wisoft.labservice.domain.home.dto.NewsUpdateRequest;
+import wisoft.labservice.domain.home.entity.News;
+import wisoft.labservice.domain.home.repository.NewsRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class NewsService {
+
+    private final NewsRepository newsRepository;
+
+    // 목록 조회
+    @Transactional(readOnly = true)
+    public List<News> findAll() {
+        return newsRepository.findAllByOrderByCreatedAtDesc();
+    }
+
+    // 등록
+    public News create(NewsCreateRequest req) {
+        if (req.getTitle() == null || req.getTitle().isBlank()) {
+            throw new IllegalArgumentException("title is required");
+        }
+
+        News news = News.builder()
+                .id(UUID.randomUUID().toString())
+                .title(req.getTitle())
+                .detail(req.getDetail())
+                .isActive(req.getIsActive())
+                .isPinned(req.getIsPinned())
+                .build();
+
+        return newsRepository.save(news);
+    }
+
+    // 수정 (PATCH)
+    public void update(String id, NewsUpdateRequest req) {
+        News news = newsRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("news not found"));
+
+        if (req.getTitle() != null) {
+            news.updateTitle(req.getTitle());
+        }
+        if (req.getDetail() != null) {
+            news.updateDetail(req.getDetail());
+        }
+        if (req.getIsActive() != null) {
+            news.updateActive(req.getIsActive());
+        }
+        if (req.getIsPinned() != null) {
+            news.updatePinned(req.getIsPinned());
+        }
+    }
+
+    // 삭제
+    public void delete(String id) {
+        if (!newsRepository.existsById(id)) {
+            throw new IllegalArgumentException("news not found");
+        }
+        newsRepository.deleteById(id);
+    }
+}


### PR DESCRIPTION
### 작업 내용
- 관리자 홈 뉴스 CRUD API 구현
- 뉴스 활성(is_active) / 고정(is_pinned) 상태 관리
- PATCH 요청 시 전달된 필드만 부분 수정하도록 처리
- JSON snake_case 전역 설정 적용

### 참고
- 관리자 API: `/admin/home/news`