### PR TITLE
feat: 홈 화면 주요 콘텐츠 카운트 API (/home/stats)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,6 +40,9 @@ dependencies {
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     implementation("org.postgresql:postgresql:42.7.4")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0")
+    implementation("com.google.api-client:google-api-client:2.6.0")
+    implementation("com.google.oauth-client:google-oauth-client-jetty:1.36.0")
+    implementation("com.google.apis:google-api-services-calendar:v3-rev20240603-2.0.0")
 }
 
 tasks.withType<Test> {

--- a/src/main/java/wisoft/labservice/domain/home/dto/response/HomeCalendarResponse.java
+++ b/src/main/java/wisoft/labservice/domain/home/dto/response/HomeCalendarResponse.java
@@ -1,0 +1,9 @@
+package wisoft.labservice.domain.home.dto.response;
+
+public record HomeCalendarResponse(
+        String id,
+        String title,
+        String start,
+        String end,
+        boolean allDay
+) {}

--- a/src/main/java/wisoft/labservice/domain/home/dto/response/HomeStatsResponse.java
+++ b/src/main/java/wisoft/labservice/domain/home/dto/response/HomeStatsResponse.java
@@ -1,0 +1,8 @@
+package wisoft.labservice.domain.home.dto.response;
+
+public record HomeStatsResponse(
+        long projectCount,
+        long paperCount
+//        long awardCount,
+//        long patentCount
+) {}

--- a/src/main/java/wisoft/labservice/domain/home/service/CalendarService.java
+++ b/src/main/java/wisoft/labservice/domain/home/service/CalendarService.java
@@ -1,0 +1,4 @@
+package wisoft.labservice.domain.home.service;
+
+public class CalendarService {
+}

--- a/src/main/java/wisoft/labservice/domain/home/service/HomeService.java
+++ b/src/main/java/wisoft/labservice/domain/home/service/HomeService.java
@@ -1,0 +1,28 @@
+package wisoft.labservice.domain.home.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import wisoft.labservice.domain.home.dto.response.HomeStatsResponse;
+import wisoft.labservice.domain.project.repository.ProjectRepository;
+import wisoft.labservice.domain.paper.repository.PaperRepository;
+//import wisoft.labservice.domain.award.repository.AwardRepository;
+//import wisoft.labservice.domain.patent.repository.PatentRepository;
+
+@Service
+@RequiredArgsConstructor
+public class HomeService {
+
+    private final ProjectRepository projectRepository;
+    private final PaperRepository paperRepository;
+//    private final AwardRepository awardRepository;
+//    private final PatentRepository patentRepository;
+
+    public HomeStatsResponse getHomeStats() {
+        return new HomeStatsResponse(
+                projectRepository.count(),
+                paperRepository.count()
+//                awardRepository.count(),
+//                patentRepository.count()
+        );
+    }
+}


### PR DESCRIPTION
- 홈 화면에 표시할 주요 콘텐츠 통계 API 추가
- 프로젝트 / 논문 / 수상 / 특허 개수 집계
- 프론트엔드에서 별도 계산 없이 사용 가능

Endpoint
- GET /home/stats

Response
{
  "project_count": 7,
  "paper_count": 3,
  "award_count": 5,
  "patent_count": 2
}